### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # app-dev
 My first repository
+
+## Princess's favorite series
+> **Cant buy me love** - *When a young man gets caught up in a deadly plot against a rich woman, he pays a devastating cost to free her - creating a debt that binds them together.*
+1. Main character
+   -*Caroline A. Tiu* - **Belle Mariano**
+   -*Andrei "Bingo" Mariano* - **Donny Pangilinan**
+
+


### PR DESCRIPTION

Can't Buy Me Love (TV Series 2023–2024) - IMDb
When a young man gets caught up in a deadly plot against a rich woman, he pays a devastating cost to free her - creating a debt that binds them together. 